### PR TITLE
C697 parse envvars

### DIFF
--- a/config/manifest.go
+++ b/config/manifest.go
@@ -6,10 +6,11 @@ import (
 )
 
 type Manifest struct {
-	Providers   []string              `json:"providers"`
-	Connections map[string]Connection `json:"connections"`
-	Variables   map[string]Variable   `json:"variables"`
-	Outputs     map[string]Output     `json:"outputs"`
+	Providers    []string               `json:"providers"`
+	Connections  map[string]Connection  `json:"connections"`
+	Variables    map[string]Variable    `json:"variables"`
+	Outputs      map[string]Output      `json:"outputs"`
+	EnvVariables map[string]EnvVariable `json:"env_variables"`
 }
 
 func (m *Manifest) Value() (driver.Value, error) {
@@ -45,4 +46,8 @@ type Output struct {
 	Type        string `json:"type"`
 	Description string `json:"description"`
 	Sensitive   bool   `json:"sensitive"`
+}
+
+type EnvVariable struct {
+	Sensitive bool `json:"sensitive"`
 }

--- a/config/parse_file_test.go
+++ b/config/parse_file_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFiles(t *testing.T) {
+	tests := []struct {
+		name            string
+		outputFile      string
+		expectedEnvVars interface{}
+	}{
+		{
+			name:            "basic",
+			outputFile:      "05/outputs.tf",
+			expectedEnvVars: map[string]EnvVariable{
+				"REDSHIFT_USER": { Sensitive: false },
+				"REDSHIFT_DB": { Sensitive: false },
+				"REDSHIFT_PASSWORD": { Sensitive: true },
+				"REDSHIFT_URL": { Sensitive: true },
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tfconfig, err := ParseFiles([]string{filepath.Join("test-fixtures", test.outputFile)})
+			require.NoError(t, err, "reading test fixture file")
+			manifest := tfconfig.ToManifest()
+			assert.Equal(t, test.expectedEnvVars, manifest.EnvVariables)
+		})
+	}
+}
+

--- a/config/parse_file_test.go
+++ b/config/parse_file_test.go
@@ -12,17 +12,28 @@ func TestParseFiles(t *testing.T) {
 	tests := []struct {
 		name            string
 		outputFile      string
-		expectedEnvVars interface{}
+		expectedOutputs map[string]Output
+		expectedEnvVars map[string]EnvVariable
 	}{
 		{
-			name:            "basic",
+			name:            "parse env and secrets",
 			outputFile:      "05/outputs.tf",
+			expectedOutputs: map[string]Output{},
 			expectedEnvVars: map[string]EnvVariable{
-				"REDSHIFT_USER": { Sensitive: false },
-				"REDSHIFT_DB": { Sensitive: false },
-				"REDSHIFT_PASSWORD": { Sensitive: true },
-				"REDSHIFT_URL": { Sensitive: true },
+				"REDSHIFT_USER":     {Sensitive: false},
+				"REDSHIFT_DB":       {Sensitive: false},
+				"REDSHIFT_PASSWORD": {Sensitive: true},
+				"REDSHIFT_URL":      {Sensitive: true},
 			},
+		},
+		{
+			name:       "fall back to regular outputs",
+			outputFile: "06/outputs.tf",
+			expectedOutputs: map[string]Output{
+				"db_instance_arn":       {Type: "string", Description: "ARN of the Postgres instance", Sensitive: false},
+				"db_master_secret_name": {Type: "string", Description: "The name of the secret in AWS Secrets Manager containing the password", Sensitive: false},
+			},
+			expectedEnvVars: map[string]EnvVariable{},
 		},
 	}
 

--- a/config/test-fixtures/05/outputs.tf
+++ b/config/test-fixtures/05/outputs.tf
@@ -1,0 +1,25 @@
+output "env" {
+  value = [
+    {
+      name  = "REDSHIFT_USER"
+      value = local.username
+    },
+    {
+      name  = "REDSHIFT_DB"
+      value = local.database_name
+    }
+  ]
+}
+
+output "secrets" {
+  value = [
+    {
+      name  = "REDSHIFT_PASSWORD"
+      value = local.password
+    },
+    {
+      name  = "REDSHIFT_URL"
+      value = "redshift://${urlencode(local.username)}:${local.password}@${local.db_endpoint}/${urlencode(local.database_name)}"
+    }
+  ]
+}

--- a/config/test-fixtures/06/outputs.tf
+++ b/config/test-fixtures/06/outputs.tf
@@ -1,0 +1,9 @@
+output "db_instance_arn" {
+  value       = aws_db_instance.this.arn
+  description = "string ||| ARN of the Postgres instance"
+}
+
+output "db_master_secret_name" {
+  value       = aws_secretsmanager_secret.password.name
+  description = "string ||| The name of the secret in AWS Secrets Manager containing the password"
+}


### PR DESCRIPTION
This PR adds a new parsing ability to the existing module parse routine. When encountered with outputs with the name `env` and `secrets`, the parser will first attempt to parse them as env variables and add them to a new EnvVariables map. If they can not be parsed as env variables, it falls back to parsing them as a standard output.